### PR TITLE
tinker: Adjust logic for more responsive control

### DIFF
--- a/app/src/main/java/com/jackingaming/thestraylightrun/accelerometer/gamecontroller/GameControllerActivity.java
+++ b/app/src/main/java/com/jackingaming/thestraylightrun/accelerometer/gamecontroller/GameControllerActivity.java
@@ -11,6 +11,7 @@ import android.hardware.SensorEvent;
 import android.hardware.SensorEventListener;
 import android.hardware.SensorManager;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.Display;
 import android.view.View;
 import android.view.WindowManager;
@@ -21,7 +22,9 @@ import com.jackingaming.thestraylightrun.R;
 
 public class GameControllerActivity extends AppCompatActivity
         implements SensorEventListener {
+    public static final String TAG = GameControllerActivity.class.getSimpleName();
 
+    private float xAccelPrevious, yAccelPrevious = 0f;
     private float xPos, xAccel, xVel = 0.0f;
     private float yPos, yAccel, yVel = 0.0f;
     private float xMax, yMax;
@@ -79,9 +82,16 @@ public class GameControllerActivity extends AppCompatActivity
     }
 
     private void updateBall() {
+        float xAccelDelta = xAccel - xAccelPrevious;
+        float yAccelDelta = yAccel - yAccelPrevious;
+
+//        Log.e(TAG, String.format("(xAccel, yAccel): (%f, %f)", (xAccel / Math.abs(xAccel)), (yAccel / Math.abs(yAccel))));
+
         float frameTime = 0.666f;
-        xVel += (xAccel * frameTime);
-        yVel += (yAccel * frameTime);
+        xVel += (xAccelDelta * frameTime);
+        yVel += (yAccelDelta * frameTime);
+
+        Log.e(TAG, String.format("(xVel, yVel): (%f, %f)", (xVel / Math.abs(xVel)), (yVel / Math.abs(yVel))));
 
         float xDelta = (xVel / 2) * frameTime;
         float yDelta = (yVel / 2) * frameTime;
@@ -100,6 +110,9 @@ public class GameControllerActivity extends AppCompatActivity
         } else if (yPos < 0) {
             yPos = 0;
         }
+
+        xAccelPrevious = xAccel;
+        yAccelPrevious = yAccel;
     }
 
     private class BallView extends View {


### PR DESCRIPTION
Instead of DIRECTLY using the device's CURRENT accelerometer values to determine the player's velocity (which determines the change of distance), use the DIFFERENCE between the CURRENT and PREVIOUS values.

The former approach requires the user to tilt the device pass the midpoint/zero-value of the axis of interest in order to change the player's direction.

This approach changes the player's direction using the change between the present and previous acceleration.